### PR TITLE
......I hate java......

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,10 +6,14 @@ services:
     depends_on:
       - db # Wait for the db to be ready
     ports:
-      - target: 8080
-        published: 80
+      - target: 8443
+        published: 443
     networks:
       - webshop
+    volumes:
+      - type: bind
+        source: /etc/letsencrypt/live/group12.web-tek.ninja-0001
+        target: /certs
     secrets:
       - db-password
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -2,6 +2,10 @@
 spring.config.import=optional:configtree:/run/secrets/
 
 # Configure access to the PostGres  database
+server.ssl.enable=true
+server.ssl.certificate=/certs/fullchain.pem
+server.ssl.certificate-private-key=/certs/privkey.pem
+server.port=8443
 driverClassName: org.postgresql.Driver
 spring.datasource.url=jdbc:postgresql://db:5432/webshop
 spring.datasource.username=postgres


### PR DESCRIPTION
As context:
Certbot is only by default giving out a ECDSA that java does not of any good reason does not support.

Only method of fixing this, is asking certbot nicely to deliver a RSA certificate instead:
https://community.letsencrypt.org/t/getting-a-rsa-privkey-from-the-letsencrypt-generated-pem/188797